### PR TITLE
Validate poll_start & poll_end Timestamp During Poll Initialization (20$)

### DIFF
--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -4,6 +4,15 @@ use anchor_lang::prelude::*;
 
 declare_id!("coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF");
 
+// poll validation error 
+#[error_code]
+pub enum PollError {
+    #[msg("Poll end time must be in the future")]
+    InvalidPollEndTime,
+    #[msg("Invalid Unix timestamp")]
+    InvalidTimestamp,
+}
+
 #[program]
 pub mod voting {
     use super::*;
@@ -13,6 +22,15 @@ pub mod voting {
                             description: String,
                             poll_start: u64,
                             poll_end: u64) -> Result<()> {
+        //current time
+        let clock = Clock::get()?;
+        let current_time = clock.unix_timestamp as u64;
+
+        //validate timestamp
+        require!(poll_end > 0, PollError::InvalidTimestamp);
+
+        // poll end time validate
+        require!(poll_end > current_time, PollError::InvalidPollEndTime);
 
         let poll = &mut ctx.accounts.poll;
         poll.poll_id = poll_id;

--- a/anchor/tests/voting.spec.ts
+++ b/anchor/tests/voting.spec.ts
@@ -20,12 +20,15 @@ describe("Voting", () => {
     );
   });
 
-  it("initializes a poll", async () => {
+  it("initializes a poll with valid end time", async () => {
+    const currentTime = Math.floor(Date.now() / 1000);
+    const futureTime = currentTime + 3600; // 1 hour in the future
+
     await votingProgram.methods.initializePoll(
       new anchor.BN(1),
       "What is your favorite color?",
-      new anchor.BN(100),
-      new anchor.BN(1739370789),
+      new anchor.BN(currentTime),
+      new anchor.BN(futureTime),
     ).rpc();
 
     const [pollAddress] = PublicKey.findProgramAddressSync(
@@ -35,11 +38,43 @@ describe("Voting", () => {
 
     const poll = await votingProgram.account.poll.fetch(pollAddress);
 
-    console.log(poll);
-
     expect(poll.pollId.toNumber()).toBe(1);
     expect(poll.description).toBe("What is your favorite color?");
-    expect(poll.pollStart.toNumber()).toBe(100);
+    expect(poll.pollStart.toNumber()).toBe(currentTime);
+    expect(poll.pollEnd.toNumber()).toBe(futureTime);
+  });
+
+  it("fails to initialize poll with past end time", async () => {
+    const currentTime = Math.floor(Date.now() / 1000);
+    const pastTime = currentTime - 3600; // 1 hour in the past
+
+    try {
+      await votingProgram.methods.initializePoll(
+        new anchor.BN(2),
+        "Past poll",
+        new anchor.BN(currentTime),
+        new anchor.BN(pastTime),
+      ).rpc();
+      // If we reach here, the test should fail
+      expect(true).toBe(false);
+    } catch (error) {
+      expect(error.toString()).toContain("Poll end time must be in the future");
+    }
+  });
+
+  it("fails to initialize poll with invalid timestamp", async () => {
+    try {
+      await votingProgram.methods.initializePoll(
+        new anchor.BN(3),
+        "Invalid timestamp poll",
+        new anchor.BN(100),
+        new anchor.BN(0), // Invalid timestamp
+      ).rpc();
+      // If we reach here, the test should fail
+      expect(true).toBe(false);
+    } catch (error) {
+      expect(error.toString()).toContain("Invalid Unix timestamp");
+    }
   });
 
   it("initializes candidates", async () => {

--- a/programs/voting/src/processor.rs
+++ b/programs/voting/src/processor.rs
@@ -2,5 +2,3 @@ use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey,
     sysvar::{clock::Clock, Sysvar},
 };
-
-// ...existing code...

--- a/programs/voting/src/processor.rs
+++ b/programs/voting/src/processor.rs
@@ -1,0 +1,6 @@
+use solana_program::{
+    account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey,
+    sysvar::{clock::Clock, Sysvar},
+};
+
+// ...existing code...


### PR DESCRIPTION
Added validation in the poll initialization to ensure poll_end is after the current time.
Added appropriate tests

registered email address : 2005akjha@gmail.com. 
 This pull request was created for https://app.gib.work/bounties/0a974cd0-3f62-4f7e-9cef-1fc0661d3dda in an attempt to solve a bounty #4 . Payment for the bounty is immediately sent to the contributor after merge.