### PR TITLE
Fix: Enforce Poll Voting Within Valid Timeframe

### DIFF
--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -35,6 +35,19 @@ pub mod voting {
 
     pub fn vote(ctx: Context<Vote>, _candidate_name: String, _poll_id: u64) -> Result<()> {
         let candidate = &mut ctx.accounts.candidate;
+        let poll = &ctx.accounts.poll;
+        let clock = Clock::get()?;
+        let current_time = clock.unix_timestamp as u64;
+
+        require!(
+            current_time >= poll.poll_start,
+            VotingError::PollNotStarted
+        );
+        require!(
+            current_time <= poll.poll_end,
+            VotingError::PollEnded
+        );
+
         candidate.candidate_votes += 1;
 
         msg!("Voted for candidate: {}", candidate.candidate_name);
@@ -124,4 +137,12 @@ pub struct Poll {
     pub poll_start: u64,
     pub poll_end: u64,
     pub candidate_amount: u64,
+}
+
+#[error_code]
+pub enum VotingError {
+    #[msg("Poll has not started yet")]
+    PollNotStarted,
+    #[msg("Poll has already ended")]
+    PollEnded,
 }

--- a/anchor/tests/voting.spec.ts
+++ b/anchor/tests/voting.spec.ts
@@ -103,4 +103,54 @@ describe("Voting", () => {
     expect(blueCandidate.candidateVotes.toNumber()).toBe(1);
     expect(blueCandidate.candidateName).toBe("Blue");
   });
+
+  it("fails when voting before poll starts", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    await votingProgram.methods.initializePoll(
+      new anchor.BN(2),
+      "Early voting test",
+      new anchor.BN(now + 1000),
+      new anchor.BN(now + 2000),
+    ).rpc();
+
+    await votingProgram.methods.initializeCandidate(
+      "Test",
+      new anchor.BN(2),
+    ).rpc();
+
+    try {
+      await votingProgram.methods.vote(
+        "Test",
+        new anchor.BN(2),
+      ).rpc();
+      throw new Error("should have failed");
+    } catch (err) {
+      expect(err.toString()).toContain("Poll has not started yet");
+    }
+  });
+
+  it("fails when voting after poll ends", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    await votingProgram.methods.initializePoll(
+      new anchor.BN(3),
+      "Late voting test",
+      new anchor.BN(now - 2000),
+      new anchor.BN(now - 1000),
+    ).rpc();
+
+    await votingProgram.methods.initializeCandidate(
+      "Test",
+      new anchor.BN(3),
+    ).rpc();
+
+    try {
+      await votingProgram.methods.vote(
+        "Test",
+        new anchor.BN(3),
+      ).rpc();
+      throw new Error("should have failed");
+    } catch (err) {
+      expect(err.toString()).toContain("Poll has already ended");
+    }
+  });
 });


### PR DESCRIPTION
Problem
The vote instruction currently allows voting at any time, without validating whether it falls within the poll's start and end times.
As a result, votes can be cast before the poll starts or after it ends, which is incorrect behavior.

Solution
Implement time validation in the vote function to ensure voting is restricted to the valid poll duration.
Add necessary test cases to verify the fix and prevent future regressions.

Email: 2005akjha@gmail.com

. 
 This pull request was created for https://app.gib.work/bounties/cbe38edf-ac9c-4ba7-9f6d-877622bda3c1 in an attempt to solve a bounty #3 . Payment for the bounty is immediately sent to the contributor after merge.